### PR TITLE
Add RabbitMQ ROCK

### DIFF
--- a/oci/rabbitmq/builds.yaml
+++ b/oci/rabbitmq/builds.yaml
@@ -1,0 +1,9 @@
+version: 1
+images: 
+  # Mirror from opendev.org longer term?
+  - source: "openstack-snaps/rock-rabbitmq"
+    commit: 9206cbf3fa6db263ea1251cf6ec819aa1192ef86
+    directory: .
+    #release-to:
+      #risks:
+      #  - beta

--- a/oci/rabbitmq/contacts.yaml
+++ b/oci/rabbitmq/contacts.yaml
@@ -1,0 +1,3 @@
+notify:
+  emails:
+    - james.page@ubuntu.com


### PR DESCRIPTION
ROCK for RabbitMQ

22.04 base with distro packages only.

Pebble service plan with automatic start.